### PR TITLE
Fix parsing TAR files with type field set to "\0"

### DIFF
--- a/src/untar-worker.js
+++ b/src/untar-worker.js
@@ -166,8 +166,9 @@ UntarFileStream.prototype = {
 
 		stream.position(dataBeginPos);
 
-		// Normal file is either "\0" or 0.
-		if (file.type === "0" || file.type === "\0") {
+		// Normal file is either "0" or "\0".
+		// In case of "\0", readString returns an empty string, that is "".
+		if (file.type === "0" || file.type === "") {
 			file.buffer = stream.readBuffer(file.size);
 		} else if (file.type == 5) {
 			// Directory - should we do anything with this? Nope!


### PR DESCRIPTION
`UntarStream.readString()` is used to parse `type` field of a TAR file. readString() returns an ASCII string excluding the terminating NULL byte ("\0"). Hence when type is set to "\0", readString() would return "" (an empty string).