### PR TITLE
Add longname option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-untar",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-untar",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "untar files in the browser",
   "main": "build/dist/untar",
   "directories": {

--- a/src/untar-worker.js
+++ b/src/untar-worker.js
@@ -291,6 +291,7 @@ UntarFileStream.prototype = {
         // and https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.bpxa500/pxarchfm.htm
         switch (file.type) {
             case "0": // Normal file is either "0" or "\0".
+            case "L": // Indicates that the next file has a long name (over 100 chars), and therefore keeps the name of the file in this block's buffer. http://www.gnu.org/software/tar/manual/html_node/Standard.html
             case "": // In case of "\0", readString returns an empty string, that is "".
                 file.buffer = stream.readBuffer(file.size);
                 break;


### PR DESCRIPTION
I ran into an issue where files of type `"L"` weren't handled by `js-untar`. In this case, the file's buffer would be empty, and I was unable to retrieve the long filename (as the following filename would be truncated). Adding case `"L"` to the applicable files in which to read from the buffer seemed to do the trick though! 

Although the filename does have a trailing null per the spec, I figured that parsing would be best left to the consumer. Any thoughts here?

Let me know if you want to add tests here--I wanted to solicit some discussion on the fix before coming up with an applicable test.

See this [stack overflow thread](https://stackoverflow.com/questions/2078778/what-exactly-is-the-gnu-tar-longlink-trick) for more info on long links.