### PR TITLE
readAsString using TextDecoder

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -24,6 +24,12 @@
                 untar(reader.result).then(
                     function (extractedFiles) { // onSuccess
                         document.getElementById('results').textContent = JSON.stringify(extractedFiles, null, 2);
+                        extractedFiles.forEach(x => {
+                            var t0 = performance.now();
+                            x.readAsString();
+                            var t1 = performance.now();
+                            console.log("x took " + (t1 - t0) + " milliseconds.")
+                        });
                     },
                     function (err) {
                         onTarError('Untar Error', err);

--- a/src/untar.js
+++ b/src/untar.js
@@ -72,21 +72,27 @@ var decoratedFileProps = {
 		}
 	},
 	readAsString: {
-		value: function() {
-			var buffer = this.buffer;
-			var charCount = buffer.byteLength;
-			var charSize = 1;
-			var byteCount = charCount * charSize;
-			var bufferView = new DataView(buffer);
+		value: function(encoding) {
+			encoding = encoding || 'utf-8';
+			if (global.TextDecoder) {				
+				var decoder = new TextDecoder(encoding);
+				return decoder.decode(this.buffer);
+			} else {
+				var buffer = this.buffer;
+				var charCount = buffer.byteLength;
+				var charSize = 1;
+				var byteCount = charCount * charSize;
+				var bufferView = new DataView(buffer);
 
-			var charCodes = [];
+				var charCodes = [];
 
-			for (var i = 0; i < charCount; ++i) {
-				var charCode = bufferView.getUint8(i * charSize, true);
-				charCodes.push(charCode);
+				for (var i = 0; i < charCount; ++i) {
+					var charCode = bufferView.getUint8(i * charSize, true);
+					charCodes.push(charCode);
+				}
+
+				return (this._string = String.fromCharCode.apply(null, charCodes));
 			}
-
-			return (this._string = String.fromCharCode.apply(null, charCodes));
 		}
 	},
 	readAsJSON: {


### PR DESCRIPTION
The "readAsString" methods uses "String.fromCharCode.apply(null, charCodes))" that will pass the whole string using the stack. That is why #25 is happening.

If the browser supports "TextDecoder" (https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder), we can use it. It is simpler, faster and solves the problem of "maximum callstack size exceeded"